### PR TITLE
Override organization name for apps started via qmlscene

### DIFF
--- a/src/UbuntuToolkit/ucapplication.cpp
+++ b/src/UbuntuToolkit/ucapplication.cpp
@@ -72,6 +72,16 @@ void UCApplication::setApplicationName(const QString& applicationName) {
        to how Unity uses it to distinguish running applications.
      */
     QCoreApplication::setApplicationName(applicationName);
+
+    /* We want to override the organization name for apps using qmlscene
+     * to be sure we get sane storage paths. Otherwise we end up with strange
+     * paths like .local/share/QtProject/$APP_NAME which breaks confinement and
+     * should actually be .local/share/$APP_NAME
+     */
+    if (QCoreApplication::organizationName() == QStringLiteral("QtProject")) {
+        QCoreApplication::setOrganizationName("");
+    }
+
     /*
        Ensure that LocalStorage and WebKit use the same location
        Docs are ambiguous: in practise applicationName is ignored by default
@@ -81,6 +91,7 @@ void UCApplication::setApplicationName(const QString& applicationName) {
     engine->setOfflineStoragePath(dataFolder);
     // Get Qtlabs.settings to use a sane path
     QCoreApplication::setOrganizationDomain(applicationName);
+
 }
 
 /*!


### PR DESCRIPTION
This is an alternative fix to https://github.com/ubports/apparmor-easyprof-ubuntu/pull/1 which retains the current behavior we currently have on vivid