### PR TITLE
Fix automaticly change of scale

### DIFF
--- a/src/UbuntuToolkit/ucunits.cpp
+++ b/src/UbuntuToolkit/ucunits.cpp
@@ -102,15 +102,12 @@ UCUnits::UCUnits(QWindow *parent) :
     m_devicePixelRatio(parent->devicePixelRatio())
 {
     m_gridUnit = getenvFloat(ENV_GRID_UNIT_PX, DEFAULT_GRID_UNIT_PX * m_devicePixelRatio);
-
-    if (!qEnvironmentVariableIsSet(ENV_GRID_UNIT_PX)) {
-        QObject::connect(parent, &QWindow::screenChanged,
-                         this, &UCUnits::screenChanged);
-        m_screen = parent->screen();
-        if (m_screen)
-            QObject::connect(m_screen, &QScreen::physicalDotsPerInchChanged,
-                             this, &UCUnits::devicePixelRatioChanged);
-    }
+    QObject::connect(parent, &QWindow::screenChanged,
+                     this, &UCUnits::screenChanged);
+    m_screen = parent->screen();
+    if (m_screen)
+        QObject::connect(m_screen, &QScreen::physicalDotsPerInchChanged,
+                         this, &UCUnits::devicePixelRatioChanged);
 }
 
 void UCUnits::screenChanged(QScreen *screen)

--- a/src/UbuntuToolkit/ucunits.cpp
+++ b/src/UbuntuToolkit/ucunits.cpp
@@ -139,12 +139,10 @@ UCUnits::UCUnits(QObject *parent) :
 {
     m_gridUnit = getenvFloat(ENV_GRID_UNIT_PX, DEFAULT_GRID_UNIT_PX * m_devicePixelRatio);
 
-    if (!qEnvironmentVariableIsSet(ENV_GRID_UNIT_PX)) {
-        auto nativeInterface = qGuiApp->platformNativeInterface();
-        if (nativeInterface) {
-            QObject::connect(nativeInterface, &QPlatformNativeInterface::windowPropertyChanged,
-                             this, &UCUnits::windowPropertyChanged);
-        }
+    auto nativeInterface = qGuiApp->platformNativeInterface();
+    if (nativeInterface) {
+        QObject::connect(nativeInterface, &QPlatformNativeInterface::windowPropertyChanged,
+                         this, &UCUnits::windowPropertyChanged);
     }
 }
 


### PR DESCRIPTION
This reverts some commits that disabled the behavior where qtmir was allowed to change scaling value based on screen connected.

This fixes: https://github.com/ubports/ubuntu-touch/issues/632