### PR TITLE
fixed the example code for docs in the PickerPanel

### DIFF
--- a/src/imports/Components/Pickers/1.3/PickerPanel.qml
+++ b/src/imports/Components/Pickers/1.3/PickerPanel.qml
@@ -34,8 +34,9 @@ import Ubuntu.Components.Popups 1.3
     \qml
     import QtQuick 2.4
     import Ubuntu.Components 1.3
+    import Ubuntu.Components.Pickers 1.3
 
-    MainWindow {
+    MainView {
         width: units.gu(40)
         height: units.gu(71)
 


### PR DESCRIPTION
not sure if docs are going to be built again but the example code wasn't working.
I added import Ubuntu.Components.Pickers 1.3
and changed MainWindow to MainView