### PR TITLE
when determining the height of the keyboard rectangle, take Screen.devicePixelRatio into account

### DIFF
--- a/src/imports/Components/1.3/OrientationHelper.qml
+++ b/src/imports/Components/1.3/OrientationHelper.qml
@@ -15,7 +15,7 @@
  */
 
 import QtQuick 2.4
-import QtQuick.Window 2.0
+import QtQuick.Window 2.2
 import Ubuntu.Components 1.3
 
 /*!
@@ -118,7 +118,7 @@ Item {
 
             var availableHeight = orientationHelper.parent.height;
             if (d.stateAngle === 0 && UbuntuApplication.inputMethod.visible && anchorToKeyboard)
-                availableHeight -= UbuntuApplication.inputMethod.keyboardRectangle.height;
+                availableHeight -= UbuntuApplication.inputMethod.keyboardRectangle.height / Screen.devicePixelRatio;
             return availableHeight;
         }
 

--- a/src/imports/Components/Pickers/1.3/PickerPanel.qml
+++ b/src/imports/Components/Pickers/1.3/PickerPanel.qml
@@ -16,7 +16,7 @@
 
 pragma Singleton
 import QtQuick 2.4
-import QtQuick.Window 2.0
+import QtQuick.Window 2.2
 import Ubuntu.Components 1.3
 import Ubuntu.Components.ListItems 1.3
 import Ubuntu.Components.Popups 1.3
@@ -204,7 +204,7 @@ Object {
             // no additional styling is needed
             color: theme.palette.normal.overlay
             width: parent.width
-            height: Qt.inputMethod.keyboardRectangle.height > 0 ? Qt.inputMethod.keyboardRectangle.height : units.gu(26)
+            height: Qt.inputMethod.keyboardRectangle.height > 0 ? Qt.inputMethod.keyboardRectangle.height / Screen.devicePixelRatio : units.gu(26)
             y: parent.height
 
             ThinDivider { anchors.bottom: parent.top }

--- a/src/imports/Components/Popups/1.3/Dialog.qml
+++ b/src/imports/Components/Popups/1.3/Dialog.qml
@@ -15,6 +15,7 @@
  */
 
 import QtQuick 2.4
+import QtQuick.Window 2.2
 import Ubuntu.Components 1.3
 import "internalPopupUtils.js" as InternalPopupUtils
 
@@ -222,7 +223,7 @@ PopupBase {
         property real margins: units.gu(4)
         property real itemSpacing: units.gu(2)
         property Item dismissArea: dialog.dismissArea
-        property real keyboardHeight: dialog.anchorToKeyboard && UbuntuApplication.inputMethod.visible ? UbuntuApplication.inputMethod.keyboardRectangle.height : 0
+        property real keyboardHeight: dialog.anchorToKeyboard && UbuntuApplication.inputMethod.visible ? UbuntuApplication.inputMethod.keyboardRectangle.height / Screen.devicePixelRatio : 0
 
         height: Math.min(contentsColumn.height + foreground.margins, dialog.height - keyboardHeight)
 


### PR DESCRIPTION
without that the popups are scrolled up too much, if the on screen keyboard is shown

see issue https://github.com/ubports/morph-browser/issues/52 of morph-browser

fixes https://github.com/ubports/morph-browser/issues/52