### PR TITLE
Use a Ash Grey for Default Button Color

### DIFF
--- a/src/imports/Components/Themes/Ambiance/1.3/ButtonStyle.qml
+++ b/src/imports/Components/Themes/Ambiance/1.3/ButtonStyle.qml
@@ -25,8 +25,7 @@ Item {
     property var button: styledItem
     property real minimumWidth: units.gu(10)
     property real horizontalPadding: units.gu(1)
-    // FIXME: Add this color to the palette
-    property color defaultColor: "#b2b2b2"
+    property color defaultColor: "#888888"
     property font defaultFont: Qt.font({family: "Ubuntu", pixelSize: FontUtils.sizeToPixels("medium")})
     property Gradient defaultGradient
     property real buttonFaceOffset: 0


### PR DESCRIPTION
Default grey used before was not in the palette.
Fixes #41