### PR TITLE
RightMargin should be 0 if columns < 2

### DIFF
--- a/src/imports/Components/1.3/AdaptivePageLayout.qml
+++ b/src/imports/Components/1.3/AdaptivePageLayout.qml
@@ -820,7 +820,9 @@ PageTreeNode {
                     bottom: parent.bottom
                     left: parent.left
                     right: parent.right
-                    rightMargin: dividerThickness + verticalDivider.width
+                    rightMargin: verticalDivider.width > 0
+                        ? dividerThickness + verticalDivider.width
+                        : 0
                 }
                 Item {
                     id: hiddenItem


### PR DESCRIPTION
That fixes the white 1 dp gap on header when adaptivePageLayout shows only one column

Before vs after

![imatge](https://user-images.githubusercontent.com/6640041/65909990-1236f000-e3ca-11e9-9c32-dfece9688007.png)

Fixes #48 