### PR TITLE
Blue, Green and Read Color Tweaks

### DIFF
--- a/components.api
+++ b/components.api
@@ -1734,7 +1734,9 @@ Ubuntu.Components.UbuntuColors 1.3: QtObject singleton
     readonly property color jet
     readonly property color lightAubergine
     readonly property color lightBlue
+    readonly property color lightGreen
     readonly property color lightGrey
+    readonly property color lightRed
     readonly property color midAubergine
     readonly property color orange
     property Gradient orangeGradient

--- a/components.api
+++ b/components.api
@@ -1733,6 +1733,7 @@ Ubuntu.Components.UbuntuColors 1.3: QtObject singleton
     readonly property color inkstone
     readonly property color jet
     readonly property color lightAubergine
+    readonly property color lightBlue
     readonly property color lightGrey
     readonly property color midAubergine
     readonly property color orange

--- a/src/imports/Components/1.3/UbuntuColors.qml
+++ b/src/imports/Components/1.3/UbuntuColors.qml
@@ -137,10 +137,16 @@ QtObject {
     readonly property color green: "#3eb34f"
 
     /*!
-      Blue. Recommended for text selection and text cursor.
+      Blue. Recommended for text selection and text cursor for Ambiance theme.
+      \since Ubuntu.Components 1.3
+     */
+    readonly property color blue: "#335280"
+
+    /*!
+      Blue. Recommended for text selection and text cursor for SuruDark theme.
       \since Ubuntu.Components 1.1
      */
-    readonly property color blue: "#19b6ee"
+    readonly property color lightBlue: "#19b6ee"
 
     /*!
       Purple. Recommended for proper nouns in

--- a/src/imports/Components/1.3/UbuntuColors.qml
+++ b/src/imports/Components/1.3/UbuntuColors.qml
@@ -128,23 +128,36 @@ QtObject {
       buttons, errors and alerts.
       \since Ubuntu.Components 1.1
      */
-    readonly property color red: "#ed3146"
+    readonly property color red: "#c7162b"
 
     /*!
-      Green. Recommended for positive action buttons.
+      Red. Recommended for negative and irreversible action
+      buttons, errors and alerts.
+      \since Ubuntu.Components 1.3
+     */
+    readonly property color lightRed: "#ed3146"
+
+    /*!
+      Green. Recommended for positive action buttons for Ambiance theme.
       \since Ubuntu.Components 1.1
      */
-    readonly property color green: "#3eb34f"
+    readonly property color green: "#0e8420"
+
+    /*!
+      Green. Recommended for positive action buttons for SuruDark theme.
+      \since Ubuntu.Components 1.3
+     */
+    readonly property color lightGreen: "#3eb34f"
 
     /*!
       Blue. Recommended for text selection and text cursor for Ambiance theme.
-      \since Ubuntu.Components 1.3
+      \since Ubuntu.Components 1.1
      */
     readonly property color blue: "#335280"
 
     /*!
       Blue. Recommended for text selection and text cursor for SuruDark theme.
-      \since Ubuntu.Components 1.1
+      \since Ubuntu.Components 1.3
      */
     readonly property color lightBlue: "#19b6ee"
 

--- a/src/imports/Components/Themes/SuruDark/1.3/Palette.qml
+++ b/src/imports/Components/Themes/SuruDark/1.3/Palette.qml
@@ -28,8 +28,8 @@ Palette {
                 raised: "#FFFFFF",
                 positiveText: UbuntuColors.porcelain,
                 negativeText: UbuntuColors.porcelain,
-                activityText: UbuntuColors.porcelain,
-                focusText: "#FFFFFF",
+                activityText: UbuntuColors.Inkstone,
+                focusText: UbuntuColors.Inkstone,
                 selectionText: "#FFFFFF"
             };
             for (var p in normal) {
@@ -59,8 +59,8 @@ Palette {
                 selectionText: "#FFFFFF",
                 positiveText: UbuntuColors.porcelain,
                 negativeText: UbuntuColors.porcelain,
-                activityText: UbuntuColors.porcelain,                
-                focusText: UbuntuColors.porcelain,
+                activityText: UbuntuColors.jet,
+                focusText: UbuntuColors.jet,
                 position: "#00000000"
             };
             for (var p in selected) {
@@ -85,7 +85,7 @@ Palette {
     }
 
     focused: SuruDarkNormal {
-        background: Qt.rgba(UbuntuColors.blue.r, UbuntuColors.blue.g, UbuntuColors.blue.b, 0.4)
+        background: Qt.rgba(UbuntuColors.lightBlue.r, UbuntuColors.lightBlue.g, UbuntuColors.lightBlue.b, 0.4)
     }
 }
 //![0]

--- a/src/imports/Components/Themes/SuruDark/1.3/Palette.qml
+++ b/src/imports/Components/Themes/SuruDark/1.3/Palette.qml
@@ -28,8 +28,8 @@ Palette {
                 raised: "#FFFFFF",
                 positiveText: UbuntuColors.porcelain,
                 negativeText: UbuntuColors.porcelain,
-                activityText: UbuntuColors.Inkstone,
-                focusText: UbuntuColors.Inkstone,
+                activityText: UbuntuColors.inkstone,
+                focusText: UbuntuColors.inkstone,
                 selectionText: "#FFFFFF"
             };
             for (var p in normal) {

--- a/src/imports/Components/Themes/SuruDark/1.3/SuruDarkNormal.qml
+++ b/src/imports/Components/Themes/SuruDark/1.3/SuruDarkNormal.qml
@@ -39,10 +39,10 @@ PaletteValues {
     focusText: "#000000"
     selection: Qt.rgba(UbuntuColors.lightBlue.r, UbuntuColors.lightBlue.g, UbuntuColors.lightBlue.b, 0.4)
     selectionText: "#FFFFFF"
-    positive: UbuntuColors.green
-    positiveText: "#FFFFFF"
-    negative: UbuntuColors.red
-    negativeText: "#FFFFFF"
+    positive: UbuntuColors.lightGreen
+    positiveText: "#000000"
+    negative: UbuntuColors.lightRed
+    negativeText: "#000000"
     activity: UbuntuColors.lightBlue
     activityText: "#000000"
     position: "#00000000"

--- a/src/imports/Components/Themes/SuruDark/1.3/SuruDarkNormal.qml
+++ b/src/imports/Components/Themes/SuruDark/1.3/SuruDarkNormal.qml
@@ -35,16 +35,16 @@ PaletteValues {
     overlaySecondaryText: UbuntuColors.slate
     field: UbuntuColors.jet
     fieldText: "#FFFFFF"
-    focus: UbuntuColors.blue
-    focusText: "#FFFFFF"
-    selection: Qt.rgba(UbuntuColors.blue.r, UbuntuColors.blue.g, UbuntuColors.blue.b, 0.4)
+    focus: UbuntuColors.lightBlue
+    focusText: "#000000"
+    selection: Qt.rgba(UbuntuColors.lightBlue.r, UbuntuColors.lightBlue.g, UbuntuColors.lightBlue.b, 0.4)
     selectionText: "#FFFFFF"
     positive: UbuntuColors.green
     positiveText: "#FFFFFF"
     negative: UbuntuColors.red
     negativeText: "#FFFFFF"
-    activity: UbuntuColors.blue
-    activityText: "#FFFFFF"
+    activity: UbuntuColors.lightBlue
+    activityText: "#000000"
     position: "#00000000"
-    positionText: UbuntuColors.blue
+    positionText: UbuntuColors.lightBlue
 }


### PR DESCRIPTION
White text on blue has [little contrast](https://contrast-ratio.com/#%23ffffff-on-%2319B6EE) so I:

- Changed UbuntuColor.blue to the [darker blue](https://contrast-ratio.com/#white-on-%23335280) we use in qqc2
- Added a lightBlue to the UbuntuColors for SuruDark
- Changed text on lightBlue for SuruDark to have better contrast

Ambiance blue:

![imatge](https://user-images.githubusercontent.com/6640041/71608378-187f6880-2b81-11ea-9cb5-3ac3d1aa32f0.png)

SuruDark:

Before:
![imatge](https://user-images.githubusercontent.com/6640041/71608065-9a21c700-2b7e-11ea-9669-3f4f185fbfaf.png)

After:
![imatge](https://user-images.githubusercontent.com/6640041/71608075-a443c580-2b7e-11ea-97a7-fb1be41f9da6.png)
