### PR TITLE
Tweak default button for Ambiance and SuruDark

### DIFF
--- a/src/imports/Components/Themes/Ambiance/1.3/ButtonStyle.qml
+++ b/src/imports/Components/Themes/Ambiance/1.3/ButtonStyle.qml
@@ -25,7 +25,7 @@ Item {
     property var button: styledItem
     property real minimumWidth: units.gu(10)
     property real horizontalPadding: units.gu(1)
-    property color defaultColor: "#888888"
+    property color defaultColor: "#666666"
     property font defaultFont: Qt.font({family: "Ubuntu", pixelSize: FontUtils.sizeToPixels("medium")})
     property Gradient defaultGradient
     property real buttonFaceOffset: 0
@@ -163,7 +163,7 @@ Item {
         /* Pick either a clear or dark text color depending on the luminance of the
            background color to maintain best contrast (works in most cases)
         */
-        textColor: ColorUtils.contrastRatio("#FFFFFF", button.color) >= 4 && !(stroke && !button.pressed) ? "#FFFFFF" : "#111111"
+        textColor: ColorUtils.contrastRatio("#FFFFFF", button.color) >= 4.1 && !(stroke && !button.pressed) ? "#FFFFFF" : "#111111"
         iconSource: button.iconSource
         iconPosition: button.iconPosition
         iconSize: units.gu(3)

--- a/src/imports/Components/Themes/SuruDark/1.3/ButtonStyle.qml
+++ b/src/imports/Components/Themes/SuruDark/1.3/ButtonStyle.qml
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2013 Canonical Ltd.
+ * Copyright 2020 UBports Fundation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.9
+import Ubuntu.Components.Themes.Ambiance 1.3 as Ambiance
+
+Ambiance.ButtonStyle {
+    property color defaultColor: "#888888"
+}


### PR DESCRIPTION
- Default button Ambiance -> graphite
- Default button SuruDark -> ash
- Tweaked contrastRatio threshold

We should end up with best contrast text on buttons:
Ambiance: darker colors, text on buttons white
SuruDark: lighter colors, text on buttons jet

![imatge](https://user-images.githubusercontent.com/6640041/72030330-f2e11600-3288-11ea-8f03-a90c4be205da.png)
