### PR TITLE
Don't hardcode Debian-specific python3 path

### DIFF
--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -1,7 +1,9 @@
 TEMPLATE = subdirs
 SUBDIRS += unit autopilot
 
-autopilot_module.path = $$[QT_INSTALL_PREFIX]/lib/python3/dist-packages/ubuntuuitoolkit
+PYTHONDIR = $$system(python3 -c \"from distutils.sysconfig import get_python_lib; print(get_python_lib())\")
+
+autopilot_module.path = $$PYTHONDIR/ubuntuuitoolkit
 autopilot_module.files = autopilot/ubuntuuitoolkit/*
 
 SUBDIRS += api


### PR DESCRIPTION
On Debian:
```
# python3 -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"
/usr/lib/python3/dist-packages
```
On Arch Linux:
```
$ python3 -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"
/usr/lib/python3.8/site-packages
```