### PR TITLE
Add include to math.h

### DIFF
--- a/src/UbuntuToolkit/colorutils.cpp
+++ b/src/UbuntuToolkit/colorutils.cpp
@@ -18,6 +18,8 @@
 
 #include <QtGui/QColor>
 
+#include <math.h>
+
 UT_NAMESPACE_BEGIN
 
 ColorUtils::ColorUtils(QObject *parent) : QObject(parent)


### PR DESCRIPTION
Fixes the following error:
```
colorutils.cpp: In static member function 'static qreal ColorUtils::contrast(const QColor&)':
colorutils.cpp:46:20: error: 'pow' was not declared in this scope
   46 |         redLight = pow((color.redF() + 0.055) / 1.055, 2.4);
      |                    ^~~
colorutils.cpp:52:22: error: 'pow' was not declared in this scope
   52 |         greenLight = pow((color.greenF() + 0.055) / 1.055, 2.4);
      |                      ^~~
colorutils.cpp:58:21: error: 'pow' was not declared in this scope
   58 |         blueLight = pow((color.blueF() + 0.055) / 1.055, 2.4);
      |                     ^~~
```