### PR TITLE
Fix missing sentinel warning

### DIFF
--- a/src/UbuntuToolkit/ucurihandler.cpp
+++ b/src/UbuntuToolkit/ucurihandler.cpp
@@ -75,7 +75,7 @@ UCUriHandler::UCUriHandler()
         qWarning() << "UCUriHandler: Empty \"APP_ID\" environment variable, ignoring.";
         return;
     }
-    char* path = nih_dbus_path(NULL, "", applicationId.constData(), NULL);
+    char* path = nih_dbus_path(NULL, "", applicationId.constData(), nullptr);
     objectPath = QString::fromLocal8Bit(path);
     nih_free(path);
 


### PR DESCRIPTION
```
ucurihandler.cpp: In constructor 'UCUriHandler::UCUriHandler()':
ucurihandler.cpp:78:73: error: missing sentinel in function call [-Werror=format=]
   78 |     char* path = nih_dbus_path(NULL, , applicationId.constData(), NULL);
      |                                                                         ^
```