### PR TITLE
Connect QObject::destroyed() directly

### DIFF
--- a/src/UbuntuToolkit/ucubuntushape.cpp
+++ b/src/UbuntuToolkit/ucubuntushape.cpp
@@ -1229,7 +1229,7 @@ QSGNode* UCUbuntuShape::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData* d
         }
         if (provider) {
             QObject::connect(provider, SIGNAL(textureChanged()), this, SLOT(_q_textureChanged()));
-            QObject::connect(provider, SIGNAL(destroyed()), this, SLOT(_q_providerDestroyed()));
+            QObject::connect(provider, SIGNAL(destroyed()), this, SLOT(_q_providerDestroyed()), Qt::DirectConnection);
         }
         m_sourceTextureProvider = provider;
     }


### PR DESCRIPTION
QObject::destroyed() is NEVER safe to connect with a queued connection. It's possible that an object is destroyed before its clients have the chance to act on the destroyed signal, resulting in keeping a dangling pointer.

In this case, this signal being connected incorrectly caused crashing on compositor restarts in Lomiri. This may have been the only time where a texture provider could be deleted before its clients. If it wasn't, though, this fix will be a good stability boost elsewhere.