### PR TITLE
[3/3] iconprovider: support getting icon theme name from QIcon and env var

### DIFF
--- a/src/UbuntuToolkit/unitythemeiconprovider_p.h
+++ b/src/UbuntuToolkit/unitythemeiconprovider_p.h
@@ -28,11 +28,12 @@ UT_NAMESPACE_BEGIN
 class UBUNTUTOOLKIT_EXPORT UnityThemeIconProvider: public QQuickImageProvider
 {
 public:
-    UnityThemeIconProvider(const QString &themeName = QStringLiteral("suru"));
+    UnityThemeIconProvider(const QString &themeName = QString());
     QImage requestImage(const QString &id, QSize *size, const QSize &requestedSize) override;
 
 private:
-    QSharedPointer<class IconTheme> theme;
+    QString m_themeName;
+    QSharedPointer<class IconTheme> getTheme();
 };
 
 UT_NAMESPACE_END

--- a/tests/unit/runtest.sh
+++ b/tests/unit/runtest.sh
@@ -149,6 +149,9 @@ function execute_test_cmd {
   return $RESULT
 }
 
+# Tests are written using this theme in mind.
+export UITK_ICON_THEME="suru"
+
 # Always create XML in case the test can't be run, eg. .so file missing
 create_fallback_xml 1 '<failure message="Test couldnt be run" result="fail"/>'
 create_test_cmd


### PR DESCRIPTION
QIcon is supposed to know best which icon theme is currently active.
Query it, so that image://theme/ uri obeys the current icon theme.

As this breaks the tests because they're written with "suru" theme in
mind, also add a way to override the icon theme via the environment
variable and use it in the test.

For QA: See if icons in the various places look correct. If possible, plug a headset with a microphone and see if the microphone slider appears and has correct-looking icon.