### PR TITLE
Compatibility with Qt 5.15

### DIFF
--- a/apicheck/apicheck.cpp
+++ b/apicheck/apicheck.cpp
@@ -911,11 +911,19 @@ int main(int argc, char *argv[])
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
             Q_FOREACH (const QQmlJS::DiagnosticMessage &e, p.errors(qmlDirFile.fileName())) {
                 QString errorString = QLatin1String("qmldir");
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+                if (e.loc.startLine > 0) {
+                    errorString += QLatin1Char(':') + QString::number(e.loc.startLine);
+                    if (e.loc.startColumn > 0)
+                        errorString += QLatin1Char(':') + QString::number(e.loc.startColumn);
+                }
+#else
                 if (e.line > 0) {
                     errorString += QLatin1Char(':') + QString::number(e.line);
                     if (e.column > 0)
                         errorString += QLatin1Char(':') + QString::number(e.column);
                 }
+#endif
 
                 errorString += QLatin1String(": ") + e.message;
                 std::cerr << qPrintable( errorString ) << std::endl;

--- a/src/UbuntuToolkit/ucqquickimageextension.cpp
+++ b/src/UbuntuToolkit/ucqquickimageextension.cpp
@@ -127,7 +127,9 @@ void UCQQuickImageExtension::reloadSource()
             ss = QSize(-1, -1);
         }
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+        if (QQuickPixmap::isCached(m_source, QRect(), ss, 0, QQuickImageProviderOptions())) {
+#elif QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
         if (QQuickPixmap::isCached(m_source, ss, 0, QQuickImageProviderOptions())) {
 #else
         if (QQuickPixmap::isCached(m_source, ss, QQuickImageProviderOptions())) {

--- a/src/imports/Test/plugin/testplugin.cpp
+++ b/src/imports/Test/plugin/testplugin.cpp
@@ -33,6 +33,7 @@ static QObject *registerExtras(QQmlEngine *engine, QJSEngine *scriptEngine)
 
 void TestPlugin::registerTypes(const char *uri)
 {
+    qmlRegisterModule(uri, 0, 1);
     qmlRegisterSingletonType<UCTestExtras>(uri, 1, 0, "TestExtras", registerExtras);
     qmlRegisterSingletonType<MouseTouchAdaptor>(uri, 1, 0, "MouseTouchAdaptor", MouseTouchAdaptor::registerQmlSingleton);
 }


### PR DESCRIPTION
Reference: 
* https://github.com/qt/qtdeclarative/commit/9cc4568de330e0075c960a5431ecd69a1f9a761d
* https://github.com/qt/qtdeclarative/commit/8ab237edf170f5b0482dccf5169868e5c7c47771

There are a few new deprecation warnings:
```
file:///[...]/qml/Ubuntu/Components/1.3/MainView.qml:195:9: QML Connections: Implicitly defined onFoo properties in Connections are deprecated. Use this syntax instead: function onFoo(<arguments>) { ... }
```
According to https://github.com/qt/qtdeclarative/commit/a2eef6b511988b2435c4e39b6b5551e857ce7775 this new syntax isn't supported in Qt 5.12 (i.e. definitely not in Qt 5.9) as such we need to wait until the minimum Qt version is > 5.12 to fix this.

```
file:///[...]/qml/Ubuntu/Components/Themes/Ambiance/1.3/ScrollbarStyle.qml:1109:5: QML Binding: Not restoring previous value because restoreMode has not been set.
This behavior is deprecated.
You have to import QtQml 2.15 after any QtQuick imports and set
the restoreMode of the binding to fix this warning.
In Qt < 6.0 the default is Binding.RestoreBinding.
In Qt >= 6.0 the default is Binding.RestoreBindingOrValue.
```
I haven't looked further into this warning yet


I believe also some components aren't actually working here but my test environment is quite incomplete so it might just be the environment
```
file:///[...]/qml/Ubuntu/Components/Pickers/1.3/Picker.qml:396: TypeError: Cannot read property 'toString' of undefined
```
edit: `Object.prototype` is undefined, not sure why that is