### PR TITLE
Fix overlayText* contrast

### DIFF
--- a/src/imports/Components/Themes/Ambiance/1.3/AmbianceNormal.qml
+++ b/src/imports/Components/Themes/Ambiance/1.3/AmbianceNormal.qml
@@ -31,8 +31,8 @@ PaletteValues {
     raisedText: UbuntuColors.slate
     raisedSecondaryText: UbuntuColors.silk
     overlay: "#FFFFFF"
-    overlayText: UbuntuColors.slate
-    overlaySecondaryText: UbuntuColors.silk
+    overlayText: UbuntuColors.inkstone
+    overlaySecondaryText: UbuntuColors.slate
     field: "#FFFFFF"
     fieldText: UbuntuColors.jet
     focus: UbuntuColors.blue

--- a/src/imports/Components/Themes/SuruDark/1.3/SuruDarkNormal.qml
+++ b/src/imports/Components/Themes/SuruDark/1.3/SuruDarkNormal.qml
@@ -31,8 +31,8 @@ PaletteValues {
     raisedText: UbuntuColors.slate
     raisedSecondaryText: UbuntuColors.silk
     overlay: UbuntuColors.inkstone
-    overlayText: "#FFFFFF"
-    overlaySecondaryText: UbuntuColors.slate
+    overlayText: UbuntuColors.porcelain
+    overlaySecondaryText: UbuntuColors.silk
     field: UbuntuColors.jet
     fieldText: "#FFFFFF"
     focus: UbuntuColors.lightBlue


### PR DESCRIPTION
- Currently overlaySecondaryText has bad contrast
- overlayText in Ambiance and SuruDark doesn't match in «distance»

![image](https://user-images.githubusercontent.com/6640041/90323848-1da1f400-df67-11ea-8a4e-af73548d48ea.png)
![image](https://user-images.githubusercontent.com/6640041/90323849-2266a800-df67-11ea-88df-11a4c73e833a.png)

After this MR should be:

![image](https://user-images.githubusercontent.com/6640041/90323858-3dd1b300-df67-11ea-8106-0ab35a458ea4.png)

Fixes: #67 