### PR TITLE
Fix crash when a touch is sent before eventFilter is installed

### DIFF
--- a/src/UbuntuGestures/touchregistry.cpp
+++ b/src/UbuntuGestures/touchregistry.cpp
@@ -74,6 +74,10 @@ void TouchRegistry::update(const QTouchEvent *event)
             touchInfo.init(touchPoint.id());
         } else if (touchPoint.state() == Qt::TouchPointReleased) {
             Pool<TouchInfo>::Iterator touchInfo = findTouchInfo(touchPoint.id());
+            if (!touchInfo) {
+                // Possibly an early touch before our eventFilter is installed.
+                continue;
+            }
 
             touchInfo->physicallyEnded = true;
         }

--- a/tests/unit/touchregistry/tst_TouchRegistry.cpp
+++ b/tests/unit/touchregistry/tst_TouchRegistry.cpp
@@ -73,6 +73,7 @@ private Q_SLOTS:
     void interimOwnerWontGetUnownedTouchEvents();
     void candidateVanishes();
     void candicateOwnershipReentrace();
+    void touchReleaseWithoutPressDoesNotCrash();
 
 private:
     TouchRegistry *touchRegistry;
@@ -918,6 +919,18 @@ void tst_TouchRegistry::candicateOwnershipReentrace()
     QCOMPARE(mainCandidate.ownedTouches.count(), 1);
     QCOMPARE(candicate2.lostTouches.count(), 1);
     QCOMPARE(candicate3.lostTouches.count(), 1);
+}
+
+void tst_TouchRegistry::touchReleaseWithoutPressDoesNotCrash() {
+    QList<QTouchEvent::TouchPoint> touchPoints;
+    touchPoints.append(QTouchEvent::TouchPoint(0));
+    touchPoints[0].setState(Qt::TouchPointReleased);
+    QTouchEvent touchEvent(QEvent::TouchEnd,
+                            0 /* device */,
+                            Qt::NoModifier,
+                            Qt::TouchPointReleased,
+                            touchPoints);
+    touchRegistry->update(&touchEvent);
 }
 
 ////////////// TouchMemento //////////


### PR DESCRIPTION
TouchRegistry may receive a released touch event for a touch that
happened before its eventFilter is installed, which means it's possible
to not have a touch info for the point. Guard access to looked-up
touchInfo so that we don't crash.