### PR TITLE
Don't assume that a list from QML is a QList or anything

### DIFF
--- a/src/UbuntuToolkit/ucbottomedge.cpp
+++ b/src/UbuntuToolkit/ucbottomedge.cpp
@@ -23,7 +23,9 @@
 #include <QtGui/QScreen>
 #include <QtGui/QStyleHints>
 #include <QtQml/QQmlEngine>
+#include <QtQml/QQmlListReference>
 #include <QtQml/QQmlProperty>
+#include <QtQml/QtQml>
 #include <QtQuick/private/qquickanimation_p.h>
 #include <QtQuick/private/qquickflickable_p.h>
 #include <QtQuick/private/qquickitem_p.h>
@@ -405,22 +407,20 @@ void UCBottomEdgePrivate::patchContentItemHeader()
 
     LOG << "PATCH HEADER" << currentContentItem.data();
     // get the navigationActions and inject an action there
-    QVariant list(header->property("navigationActions"));
-    QQmlListProperty<UCAction> actions = list.value< QQmlListProperty<UCAction> >();
-    QList<UCAction*> *navigationActions = reinterpret_cast<QList<UCAction*>*>(actions.data);
+    QQmlListReference navigationActions(header, /* property */ "navigationActions", qmlEngine(q_func()));
 
     // do we have any action in the list?
-    if (navigationActions->size()) {
+    if (navigationActions.count()) {
         // we have actions in the list, check if those are ours
-        UCCollapseAction *collapse = qobject_cast<UCCollapseAction*>(navigationActions->at(0));
+        UCCollapseAction *collapse = qobject_cast<UCCollapseAction*>(navigationActions.at(0));
         if (!collapse) {
             // not ours, clear the list
-            navigationActions->clear();
+            navigationActions.clear();
         }
     }
-    if (navigationActions->size() <= 0) {
+    if (navigationActions.count() <= 0) {
         // no actions, patch
-        navigationActions->append(new UCCollapseAction(header));
+        navigationActions.append(new UCCollapseAction(header));
 
         // invoke PageHeader.navigationActionsChanged signal
         int signal = header->metaObject()->indexOfSignal("navigationActionsChanged()");
@@ -432,7 +432,7 @@ void UCBottomEdgePrivate::patchContentItemHeader()
     // are we committed?
     if (status == UCBottomEdge::Committed) {
         // activate the action
-        UCCollapseAction *collapse = qobject_cast<UCCollapseAction*>(navigationActions->at(0));
+        UCCollapseAction *collapse = qobject_cast<UCCollapseAction*>(navigationActions.at(0));
         Q_ASSERT(collapse);
         collapse->activate();
         QObject::connect(collapse, &UCAction::triggered, q_func(), &UCBottomEdge::collapse, Qt::DirectConnection);

--- a/tests/unit/bottomedge/tst_bottomedge.cpp
+++ b/tests/unit/bottomedge/tst_bottomedge.cpp
@@ -27,6 +27,8 @@
 #include <UbuntuToolkit/private/quickutils_p.h>
 #include <UbuntuToolkit/private/ucbottomedgestyle_p.h>
 #undef private
+#include <QtQml/QQmlListReference>
+#include <QtQml/QtQml>
 #include <QtTest/QtTest>
 
 #include "uctestcase.h"
@@ -98,13 +100,11 @@ public:
             return false;
         }
 
-        QVariant list(header->property("navigationActions"));
-        QQmlListProperty<UCAction> actions = list.value< QQmlListProperty<UCAction> >();
-        QList<UCAction*> *navigationActions = reinterpret_cast<QList<UCAction*>*>(actions.data);
-        if (navigationActions->size() <= 0) {
+        QQmlListReference navigationActions(header, /* property */ "navigationActions", qmlEngine(header));
+        if (navigationActions.count() <= 0) {
             return false;
         }
-        return (qobject_cast<UCCollapseAction*>(navigationActions->at(0)) != Q_NULLPTR);
+        return (qobject_cast<UCCollapseAction*>(navigationActions.at(0)) != Q_NULLPTR);
     }
 
     void guToPoints(QList<QPoint> &guMoves)
@@ -853,7 +853,6 @@ private Q_SLOTS:
     }
     void test_autocollapse_navigation_action_on_commit_completed()
     {
-        QSKIP("FIXME: Crashing on Qt 5.12");
         QFETCH(QString, document);
 
         auto test = new BottomEdgeTestCase(document);


### PR DESCRIPTION
Qt can change this internal detail at any time, and they've done so in
5.12.8 & 5.15.0. Instead, use QQmlListReference, which is a documented
way of accessing a QML list.