### PR TITLE
Improve Dialog style

### DIFF
--- a/src/imports/Components/Popups/1.3/PopupBase.qml
+++ b/src/imports/Components/Popups/1.3/PopupBase.qml
@@ -155,7 +155,9 @@ OrientationHelper {
         property bool dim: false
         anchors.fill: parent
         visible: dim
-        color: popupBase.width > units.gu(60) ? Qt.rgba(0, 0, 0, 0.6) : Qt.rgba(0, 0, 0, 0.9)
+        color: popupBase.width > units.gu(60) ?
+               Qt.rgba(UbuntuColors.inkstone.r, UbuntuColors.inkstone.g, UbuntuColors.inkstone.b, 0.6) :
+               Qt.rgba(UbuntuColors.inkstone.r, UbuntuColors.inkstone.g, UbuntuColors.inkstone.b, 0.9)
     }
 
     InverseMouseArea {

--- a/src/imports/Components/Themes/Ambiance/1.3/DialogForegroundStyle.qml
+++ b/src/imports/Components/Themes/Ambiance/1.3/DialogForegroundStyle.qml
@@ -23,6 +23,6 @@ Item {
     UbuntuShape {
         id: background
         anchors.fill: parent
-        backgroundColor: theme.palette.normal.overlay
+        backgroundColor: theme.palette.normal.background
     }
 }


### PR DESCRIPTION
use `theme.palettenormal.background` for Dialog background and `UbuntuColors.inkstone` to dim the content behind

Checkboxes are now more visible (#91) and the `TextField` color isn't darker that the background anymore

![immagine](https://user-images.githubusercontent.com/28359593/95854416-39532c00-0d57-11eb-8954-cc16a3775a56.png)![immagine](https://user-images.githubusercontent.com/28359593/95854436-3fe1a380-0d57-11eb-9e74-436c70243493.png)![immagine](https://user-images.githubusercontent.com/28359593/95854397-322c1e00-0d57-11eb-8167-87e803307d0d.png)