### PR TITLE
Consider Dialog theme for dim color instead of the app theme

### DIFF
--- a/src/imports/Components/Popups/1.3/PopupBase.qml
+++ b/src/imports/Components/Popups/1.3/PopupBase.qml
@@ -155,7 +155,7 @@ OrientationHelper {
         property bool dim: false
         anchors.fill: parent
         visible: dim
-        property color dimC: Theme.name == "Ubuntu.Components.Themes.Ambiance" ? UbuntuColors.jet : UbuntuColors.inkstone
+        property color dimC: __foreground.theme.name == "Ubuntu.Components.Themes.Ambiance" ? UbuntuColors.jet : UbuntuColors.inkstone
         color: popupBase.width > units.gu(60) ? Qt.rgba(dimC.r, dimC.g, dimC.b, 0.6) : Qt.rgba(dimC.r, dimC.g, dimC.b, 0.9)
     }
 


### PR DESCRIPTION
Sorry if I didn't tested deeper my previous PR about Dialog style but this was totally unexpected: the Dialog can have a different theme from the app theme. One example? The Lomiri shutdown Dialog! The Dialog's theme is Ambiance while the shell one is SuruDark

Before vs after this fix

![immagine](https://user-images.githubusercontent.com/28359593/96143370-5298db80-0f03-11eb-90c1-e34d98818493.png)![immagine](https://user-images.githubusercontent.com/28359593/96143330-49a80a00-0f03-11eb-9cc3-e186330fd5cf.png)
