### PR TITLE
OptionSelectorDelegate: avoid error when modelData is undefined and option.text===""

### DIFF
--- a/src/imports/Components/1.3/OptionSelectorDelegate.qml
+++ b/src/imports/Components/1.3/OptionSelectorDelegate.qml
@@ -321,7 +321,7 @@ ListItem.Empty {
                 - parent.spacing * 2 - parent.anchors.leftMargin
 
             Toolkit.Label {
-                text: (option.text === "" && typeof modelData !== "undefined") ? modelData : option.text
+                text: (option.text === "" && modelData !== undefined) ? modelData : option.text
                 width: parent.width
                 elide: Text.ElideRight
             }

--- a/src/imports/Components/1.3/OptionSelectorDelegate.qml
+++ b/src/imports/Components/1.3/OptionSelectorDelegate.qml
@@ -321,7 +321,7 @@ ListItem.Empty {
                 - parent.spacing * 2 - parent.anchors.leftMargin
 
             Toolkit.Label {
-                text: option.text === "" ? modelData : option.text
+                text: (option.text === "" && typeof modelData !== "undefined") ? modelData : option.text
                 width: parent.width
                 elide: Text.ElideRight
             }


### PR DESCRIPTION
see issue #105 