### PR TITLE
fix DatePickers not shown when loaded from AdaptiveLayout.

### DIFF
--- a/src/imports/Components/Pickers/1.3/DatePicker.qml
+++ b/src/imports/Components/Pickers/1.3/DatePicker.qml
@@ -576,28 +576,6 @@ StyledItem {
                 }
 
                 arrangeTumblers();
-                resetPickers();
-            }
-        }
-
-        /*
-          Resets the pickers. Pickers will update their models with the given date,
-          minimum and maximum values.
-          */
-        function resetPickers() {
-            if (!completed) return;
-            for (var i = 0; i < tumblerModel.count; i++) {
-                var pickerItem = tumblerModel.get(i).pickerModel.pickerItem;
-                pickerItem.resetPicker();
-            }
-
-            // calculate the ratio for the dayPicker
-            var maxWidth = 0.0;
-            maxWidth += showYearPicker ? yearModel.longFormatLimit : 0.0;
-            maxWidth += showMonthPicker ? monthModel.longFormatLimit : 0.0;
-            maxWidth += showDayPicker ? dayModel.longFormatLimit : 0.0;
-            if (showDayPicker && maxWidth > 0.0) {
-                dayPickerRatio = (dayModel.longFormatLimit / maxWidth).toPrecision(3);
             }
         }
 
@@ -663,6 +641,15 @@ StyledItem {
                 formatIndex++;
             } else {
                 tumblerModel.removePicker("SecondsPicker");
+            }
+
+            // calculate the ratio for the dayPicker
+            var maxWidth = 0.0;
+            maxWidth += showYearPicker ? yearModel.longFormatLimit : 0.0;
+            maxWidth += showMonthPicker ? monthModel.longFormatLimit : 0.0;
+            maxWidth += showDayPicker ? dayModel.longFormatLimit : 0.0;
+            if (showDayPicker && maxWidth > 0.0) {
+                dayPickerRatio = (dayModel.longFormatLimit / maxWidth).toPrecision(3);
             }
 
             // re-enable completion

--- a/src/imports/Components/Pickers/1.3/PickerRow.qml
+++ b/src/imports/Components/Pickers/1.3/PickerRow.qml
@@ -129,7 +129,7 @@ Row {
             Component.onCompleted: {
                 // update model with the item instance
                 pickerModel.pickerItem = unitPicker;
-                resetPicker()
+                resetPicker();
                 unitPicker.onMovingChanged.connect(pickerMoving.bind(unitPicker));
                 row.pickerMoving(unitPicker.moving);
             }

--- a/src/imports/Components/Pickers/1.3/PickerRow.qml
+++ b/src/imports/Components/Pickers/1.3/PickerRow.qml
@@ -129,6 +129,7 @@ Row {
             Component.onCompleted: {
                 // update model with the item instance
                 pickerModel.pickerItem = unitPicker;
+                resetPicker()
                 unitPicker.onMovingChanged.connect(pickerMoving.bind(unitPicker));
                 row.pickerMoving(unitPicker.moving);
             }


### PR DESCRIPTION
fixes #109 

As AdaptiveLayout default is asynchronous loading, some date pickers components are not fully loaded and makes the data not displayed.
The idea is to wait for full completion before populate the data